### PR TITLE
refactor: extract data module from app.py

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,50 +5,12 @@ import pandas as pd
 from shiny import App, reactive, render, ui
 from shinywidgets import output_widget, render_altair
 
-
-DATA_PATH = Path(__file__).parent.parent / "data" / "raw" / "financial_statement.csv"
-
-
-def load_data(path: Path) -> pd.DataFrame:
-    """Load and clean the financial dataset."""
-    if not path.exists():
-        raise FileNotFoundError(f"Dataset not found: {path}")
-    data = pd.read_csv(path, encoding="utf-8-sig")
-    data.columns = data.columns.str.strip()
-    data["Category"] = data["Category"].str.upper()
-    return data
-
-
-df = load_data(DATA_PATH)
+from data import df, CATEGORY_COMPANIES, ALL_SECTORS, METRIC_CHOICES
 
 # Load custom CSS from external file
 CSS_PATH = Path(__file__).parent.parent / "assets" / "custom_styles.css"
 with open(CSS_PATH, "r") as css_file:
     CUSTOM_CSS = ui.tags.style(css_file.read())
-
-CATEGORY_COMPANIES = {
-    "BANK": ["AIG", "BCS"],
-    "ELEC": ["INTC", "NVDA"],
-    "FINANCE": ["SHLDQ"],
-    "FINTECH": ["PYPL"],
-    "FOOD": ["MCD"],
-    "IT": ["AAPL", "GOOG", "MSFT"],
-    "LOGI": ["AMZN"],
-    "MANUFACTURING": ["PCG"],
-}
-ALL_SECTORS = sorted(CATEGORY_COMPANIES.keys())
-
-METRIC_CHOICES = {
-    "Net Profit Margin": "%",
-    "ROE": "%",
-    "ROA": "%",
-    "ROI": "%",
-    "Revenue": "USD",
-    "Net Income": "USD",
-    "EBITDA": "USD",
-    "Current Ratio": "",
-    "Debt/Equity Ratio": "",
-}
 
 
 # Page 1: Sector Analysis

--- a/src/data.py
+++ b/src/data.py
@@ -1,0 +1,44 @@
+"""Data loading, cleaning, and shared constants for the fin-health dashboard."""
+
+from pathlib import Path
+
+import pandas as pd
+
+DATA_PATH = Path(__file__).parent.parent / "data" / "raw" / "financial_statement.csv"
+
+
+def load_data(path: Path = DATA_PATH) -> pd.DataFrame:
+    """Load and clean the financial dataset."""
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset not found: {path}")
+    data = pd.read_csv(path, encoding="utf-8-sig")
+    data.columns = data.columns.str.strip()
+    data["Category"] = data["Category"].str.upper()
+    return data
+
+
+df = load_data()
+
+CATEGORY_COMPANIES = {
+    "BANK": ["AIG", "BCS"],
+    "ELEC": ["INTC", "NVDA"],
+    "FINANCE": ["SHLDQ"],
+    "FINTECH": ["PYPL"],
+    "FOOD": ["MCD"],
+    "IT": ["AAPL", "GOOG", "MSFT"],
+    "LOGI": ["AMZN"],
+    "MANUFACTURING": ["PCG"],
+}
+ALL_SECTORS = sorted(CATEGORY_COMPANIES.keys())
+
+METRIC_CHOICES = {
+    "Net Profit Margin": "%",
+    "ROE": "%",
+    "ROA": "%",
+    "ROI": "%",
+    "Revenue": "USD",
+    "Net Income": "USD",
+    "EBITDA": "USD",
+    "Current Ratio": "",
+    "Debt/Equity Ratio": "",
+}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from app import df
+from data import df
 
 
 def test_data_loaded_successfully():
@@ -10,5 +10,18 @@ def test_data_loaded_successfully():
 
 def test_expected_columns_present():
     """Verify key columns required by the app exist after loading."""
-    expected = {"Year", "Company", "Category", "Net Profit Margin", "ROE", "ROA", "ROI", "Revenue", "Net Income", "EBITDA", "Current Ratio", "Debt/Equity Ratio"}
+    expected = {
+        "Year",
+        "Company",
+        "Category",
+        "Net Profit Margin",
+        "ROE",
+        "ROA",
+        "ROI",
+        "Revenue",
+        "Net Income",
+        "EBITDA",
+        "Current Ratio",
+        "Debt/Equity Ratio",
+    }
     assert expected.issubset(set(df.columns))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from data import df, load_data, ALL_SECTORS, METRIC_CHOICES, CATEGORY_COMPANIES
+
+
+def test_load_data_returns_dataframe():
+    """Verify load_data() returns a non-empty DataFrame."""
+    result = load_data()
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_expected_columns_present():
+    """Verify key columns required by the app exist after loading."""
+    expected = {
+        "Year",
+        "Company",
+        "Category",
+        "Net Profit Margin",
+        "ROE",
+        "ROA",
+        "ROI",
+        "Revenue",
+        "Net Income",
+        "EBITDA",
+        "Current Ratio",
+        "Debt/Equity Ratio",
+    }
+    assert expected.issubset(set(df.columns))
+
+
+def test_all_sectors_sorted():
+    """Verify ALL_SECTORS is a sorted list of category keys."""
+    assert ALL_SECTORS == sorted(CATEGORY_COMPANIES.keys())
+
+
+def test_metric_choices_non_empty():
+    """Verify METRIC_CHOICES contains expected metrics."""
+    assert len(METRIC_CHOICES) > 0
+    assert "Net Profit Margin" in METRIC_CHOICES
+    assert "Revenue" in METRIC_CHOICES
+
+
+def test_category_companies_has_entries():
+    """Verify CATEGORY_COMPANIES maps sectors to company lists."""
+    assert len(CATEGORY_COMPANIES) > 0
+    for sector, companies in CATEGORY_COMPANIES.items():
+        assert isinstance(companies, list)
+        assert len(companies) > 0


### PR DESCRIPTION
## Summary
- Created `src/data.py` with `load_data()`, `df`, `CATEGORY_COMPANIES`, `ALL_SECTORS`, `METRIC_CHOICES`
- Updated `app.py` to import from `data` module instead of defining data loading inline
- Added `tests/test_data.py` with 5 tests covering data loading and constants
- Updated `tests/test_app.py` imports for new module structure

## Test plan
- [x] `pytest tests/` passes with 7 tests (5 new + 2 updated)
- [x] `shiny run src/app.py` still works
- [x] No import errors

> Tasks 3–5 depend on this PR being merged first.