### PR TITLE
fix: CSS cleanup — remove duplicates, scope transitions, define variables

### DIFF
--- a/assets/custom_styles.css
+++ b/assets/custom_styles.css
@@ -1,5 +1,6 @@
 :root {
     --primary: #2563eb;
+    --primary-light: #60a5fa;
     --success: #009e73;
     --danger: #d55e00;
     --warning: #f59e0b;
@@ -11,6 +12,8 @@
     --slate-600: #475569;
     --slate-700: #334155;
     --slate-900: #0f172a;
+    --section-blue: #2980b9;
+    --section-red: #c0392b;
 }
 
 body { 
@@ -217,8 +220,15 @@ select:focus {
     padding: 1rem;
 }
 
-/* Transitions for micro-interactions */
-* {
+/* Transitions for micro-interactions — scoped to interactive elements */
+a,
+button,
+input,
+select,
+textarea,
+.btn,
+.nav-link,
+.card {
     transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -240,30 +250,30 @@ select:focus {
     color: var(--primary);
 }
 
-/* Page 2 Vertical group styling*/
+/* Page 2 Vertical group styling */
 .section-label {
     writing-mode: vertical-rl;
     text-orientation: upright;
     color: white;
     font-weight: bold;
-    /*padding: 0.5rem 0.4rem 1rem 0.4rem;*/
     border-radius: 6px;
     text-align: center;
     letter-spacing: 1px;
-    font-size: 0.65em;
+    font-size: 0.7rem;
     display: flex;
     align-items: center;
     justify-content: center;
     white-space: nowrap;
     flex-shrink: 0;
+    height: 100%;
 }
 
-.section-label-blue { 
-    background-color: #2980b9; 
+.section-label-blue {
+    background-color: var(--section-blue);
 }
 
-.section-label-red { 
-    background-color: #c0392b; 
+.section-label-red {
+    background-color: var(--section-red);
 }
 
 /* Footer styling */
@@ -301,19 +311,4 @@ select:focus {
 /* Ensure the cards inside the grid take full width */
 .grid-section .shiny-layout-column {
     width: 100%;
-}
-
-/* Updated label styling to ensure it fills the grid height */
-.section-label {
-    writing-mode: vertical-rl;
-    text-orientation: upright;
-    color: white;
-    font-weight: bold;
-    border-radius: 6px;
-    text-align: center;
-    font-size: 0.7rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%; /* Fill the grid height */
 }


### PR DESCRIPTION
Closes #26 

## Summary

- **Merged duplicate `.section-label` CSS blocks** into a single consolidated rule (was defined twice with slightly different properties; now one block with `height: 100%`, `font-size: 0.7rem`, `white-space: nowrap`, and `flex-shrink: 0`)
- **Replaced wildcard `*` transition** with targeted selectors (`a`, `button`, `input`, `select`, `textarea`, `.btn`, `.nav-link`, `.card`) to avoid unnecessary transition overhead on all elements
- **Defined `--primary-light: #60a5fa`** CSS variable in `:root`
- **Replaced hardcoded colors** in `.section-label-blue` (`#2980b9`) and `.section-label-red` (`#c0392b`) with new CSS variables `--section-blue` and `--section-red`
- **Verified no unused classes** (`.progress-bar-container`, `.progress-bar-fill`, `.status-badge`, `.metric-change`, `.label-wrapper`, `.kpi-big`) exist in the stylesheet — none were present, so no removal was needed
- **Verified `.kpi-label`** has only one definition (the `0.9rem` version) — no duplicate to remove

## Test plan

- [x] Verify the dashboard renders correctly with no visual regressions
- [x] Confirm section labels on Page 2 display properly (vertical text, correct colors)
- [x] Check that hover transitions still work on cards, nav links, buttons, and inputs
- [x] Verify KPI labels are styled correctly

