### PR TITLE
refactor: extract reusable components (kpi_card, empty_chart)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,6 +6,8 @@ from shiny import App, reactive, render, ui
 from shinywidgets import output_widget, render_altair
 
 from data import df, CATEGORY_COMPANIES, ALL_SECTORS, METRIC_CHOICES
+from components.kpi_card import kpi_card
+from components.empty_chart import empty_chart
 
 # Load custom CSS from external file
 CSS_PATH = Path(__file__).parent.parent / "assets" / "custom_styles.css"
@@ -45,52 +47,22 @@ def page1_sector_analysis():
     )
 
     # KPI cards
-    card_avg_margin = ui.card(
-        ui.card_header("Avg Profit Margin"),
-        ui.tags.div(
-            ui.tags.h3(
-                ui.output_text("p1_avg_margin", inline=True),
-                class_="kpi-value",
-                style="display: inline;",
-            ),
-            ui.output_ui("p1_margin_trend", style="display: inline;"),
-            class_="kpi-value-row",
-        ),
-        ui.tags.div(
-            ui.output_ui("p1_margin_badge"),
-            class_="kpi-label-row",
-        ),
+    card_avg_margin = kpi_card(
+        header="Avg Profit Margin",
+        value_id="p1_avg_margin",
+        trend_id="p1_margin_trend",
+        label_id="p1_margin_badge",
     )
-    card_top_sector = ui.card(
-        ui.card_header("Top Sector"),
-        ui.tags.div(
-            ui.tags.h3(
-                ui.output_text("p1_top_sector", inline=True),
-                class_="kpi-value",
-                style="display: inline;",
-            ),
-            class_="kpi-value-row",
-        ),
-        ui.tags.div(
-            ui.output_ui("p1_index_performance_display"),
-            class_="kpi-label-row",
-        ),
+    card_top_sector = kpi_card(
+        header="Top Sector",
+        value_id="p1_top_sector",
+        label_id="p1_index_performance_display",
     )
-    card_revenue_growth = ui.card(
-        ui.card_header("Revenue Growth"),
-        ui.tags.div(
-            ui.output_ui("p1_revenue_growth_display"),
-            ui.output_ui("p1_revenue_trend", style="display: inline;"),
-            class_="kpi-value-row",
-        ),
-        ui.tags.div(
-            ui.tags.p(
-                "YEAR OVER YEAR",
-                class_="kpi-label",
-                style="margin-top: 0.5rem;",
-            ),
-            class_="kpi-label-row",
-        ),
+    card_revenue_growth = kpi_card(
+        header="Revenue Growth",
+        value_id="p1_revenue_growth_value",
+        trend_id="p1_revenue_trend",
+        label_id="p1_revenue_growth_label",
     )
     kpi_row = ui.layout_columns(
         card_avg_margin,
@@ -437,18 +409,20 @@ def server(input, output, session):
         revenue_growth = (current - previous) / previous * 100
         return {"value": revenue_growth, "is_positive": revenue_growth >= 0}
 
-    @render.ui
-    def p1_revenue_growth_display():
+    @render.text
+    def p1_revenue_growth_value():
         change = p1_revenue_change()
         if change is None:
-            return ui.tags.h3(
-                "Data Unavailable", class_="kpi-value", style="display: inline;"
-            )
+            return "Data Unavailable"
         sign = "+" if change["is_positive"] else ""
-        return ui.tags.h3(
-            f"{sign}{change['value']:.1f}%",
-            class_="kpi-value",
-            style="display: inline;",
+        return f"{sign}{change['value']:.1f}%"
+
+    @render.ui
+    def p1_revenue_growth_label():
+        return ui.tags.p(
+            "YEAR OVER YEAR",
+            class_="kpi-label",
+            style="margin-top: 0.5rem;",
         )
 
     @render.ui
@@ -471,15 +445,7 @@ def server(input, output, session):
 
         avg_by_sector = filtered.groupby("Category")[metric].mean().reset_index()
         if avg_by_sector.empty:
-            return (
-                alt.Chart(
-                    pd.DataFrame({"x": [0], "y": [0], "text": ["Data Unavailable"]})
-                )
-                .mark_text(size=18)
-                .encode(
-                    text="text:N",
-                )
-            )
+            return empty_chart()
         chart = (
             alt.Chart(avg_by_sector)
             .mark_bar()
@@ -515,15 +481,7 @@ def server(input, output, session):
         ].mean()
 
         if observed_trend.empty:
-            return (
-                alt.Chart(
-                    pd.DataFrame({"x": [0], "y": [0], "text": ["Data Unavailable"]})
-                )
-                .mark_text(size=18)
-                .encode(
-                    text="text:N",
-                )
-            )
+            return empty_chart()
 
         metric_trend = (
             alt.Chart(observed_trend)
@@ -545,15 +503,7 @@ def server(input, output, session):
         unit = METRIC_CHOICES[metric]
 
         if filtered.empty:
-            return (
-                alt.Chart(
-                    pd.DataFrame({"x": [0], "y": [0], "text": ["Data Unavailable"]})
-                )
-                .mark_text(size=18)
-                .encode(
-                    text="text:N",
-                )
-            )
+            return empty_chart()
 
         chart = (
             alt.Chart(filtered)

--- a/src/components/empty_chart.py
+++ b/src/components/empty_chart.py
@@ -1,0 +1,13 @@
+"""Reusable empty-state Altair chart for fallback display."""
+
+import altair as alt
+import pandas as pd
+
+
+def empty_chart(message: str = "Data Unavailable") -> alt.Chart:
+    """Return a text-only Altair chart for empty-state fallback."""
+    return (
+        alt.Chart(pd.DataFrame({"text": [message]}))
+        .mark_text(size=18)
+        .encode(text="text:N")
+    )

--- a/src/components/kpi_card.py
+++ b/src/components/kpi_card.py
@@ -1,0 +1,39 @@
+"""Reusable KPI card factory for consistent card layouts."""
+
+from shiny import ui
+
+
+def kpi_card(header: str, value_id: str, trend_id: str = None, label_id: str = None):
+    """Build a KPI card with consistent structure.
+
+    Parameters
+    ----------
+    header : str
+        Card header text.
+    value_id : str
+        Output ID for the main KPI value (used with @render.text).
+    trend_id : str, optional
+        Output ID for the trend indicator (used with @render.ui).
+    label_id : str, optional
+        Output ID for the label row below the value (used with @render.ui).
+    """
+    value_children = [
+        ui.tags.h3(
+            ui.output_text(value_id, inline=True),
+            class_="kpi-value",
+            style="display: inline;",
+        )
+    ]
+    if trend_id:
+        value_children.append(ui.output_ui(trend_id, style="display: inline;"))
+
+    label_row = ui.tags.div(
+        ui.output_ui(label_id) if label_id else ui.tags.span(),
+        class_="kpi-label-row",
+    )
+
+    return ui.card(
+        ui.card_header(header),
+        ui.tags.div(*value_children, class_="kpi-value-row"),
+        label_row,
+    )

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,32 @@
+import altair as alt
+from components.kpi_card import kpi_card
+from components.empty_chart import empty_chart
+
+
+def test_kpi_card_returns_ui_element():
+    """Verify kpi_card() returns a valid Shiny UI element."""
+    card = kpi_card(header="Test", value_id="test_value")
+    assert card is not None
+
+
+def test_kpi_card_with_trend_and_label():
+    """Verify kpi_card() with all optional parameters."""
+    card = kpi_card(
+        header="Test",
+        value_id="test_value",
+        trend_id="test_trend",
+        label_id="test_label",
+    )
+    assert card is not None
+
+
+def test_empty_chart_returns_altair_chart():
+    """Verify empty_chart() returns an alt.Chart object."""
+    chart = empty_chart()
+    assert isinstance(chart, alt.Chart)
+
+
+def test_empty_chart_custom_message():
+    """Verify empty_chart() accepts a custom message."""
+    chart = empty_chart("No data found")
+    assert isinstance(chart, alt.Chart)


### PR DESCRIPTION
## Summary
- Created `src/components/kpi_card.py` — factory function replacing 3 inline KPI card definitions
- Created `src/components/empty_chart.py` — reusable "Data Unavailable" chart replacing 3 copy-pasted blocks
- Refactored revenue growth output to use `@render.text` for `kpi_card()` compatibility
- Added `tests/test_components.py` with 4 tests

## Test plan
- [x] `pytest tests/` passes with 11 tests
- [x] `shiny run src/app.py` still works — KPI cards render correctly
- [x] Empty chart fallback displays when data is filtered to empty

> Task 4 (chart builders) depends on this PR being merged.

Closes #18 