### PR TITLE
refactor: extract chart builders into pure functions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,13 +1,16 @@
 from pathlib import Path
 import subprocess
-import altair as alt
 import pandas as pd
 from shiny import App, reactive, render, ui
 from shinywidgets import output_widget, render_altair
 
 from data import df, CATEGORY_COMPANIES, ALL_SECTORS, METRIC_CHOICES
 from components.kpi_card import kpi_card
-from components.empty_chart import empty_chart
+from charts.altair_charts import (
+    build_sector_bar,
+    build_metric_trend,
+    build_peer_scatter,
+)
 
 # Load custom CSS from external file
 CSS_PATH = Path(__file__).parent.parent / "assets" / "custom_styles.css"
@@ -442,26 +445,7 @@ def server(input, output, session):
         filtered = p1_filtered_data()
         metric = p1_selected_metric()
         unit = METRIC_CHOICES[metric]
-
-        avg_by_sector = filtered.groupby("Category")[metric].mean().reset_index()
-        if avg_by_sector.empty:
-            return empty_chart()
-        chart = (
-            alt.Chart(avg_by_sector)
-            .mark_bar()
-            .encode(
-                x=alt.X("Category:N", title="Sector", sort="-y"),
-                y=alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
-                color=alt.Color(
-                    "Category:N",
-                    scale=alt.Scale(scheme="viridis"),
-                    legend=None,
-                ),
-                tooltip=["Category", alt.Tooltip(f"{metric}:Q", format=".2f")],
-            )
-            .properties(title=f"Average {metric} by Sector", width="container")
-        )
-        return chart
+        return build_sector_bar(filtered, metric, unit)
 
     # Metric Based Trend
     # Change p1_chart_b header based on metric filter selection
@@ -475,25 +459,7 @@ def server(input, output, session):
         filtered = p1_filtered_data()
         metric = p1_selected_metric()
         unit = METRIC_CHOICES[metric]
-
-        observed_trend = filtered.groupby(["Year", "Category"], as_index=False)[
-            metric
-        ].mean()
-
-        if observed_trend.empty:
-            return empty_chart()
-
-        metric_trend = (
-            alt.Chart(observed_trend)
-            .mark_line(point=True)
-            .encode(
-                alt.X("Year:O", title="Year"),
-                alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
-                color=alt.Color("Category:N", scale=alt.Scale(scheme="viridis")),
-                tooltip=["Year", "Category", alt.Tooltip(f"{metric}:Q", format=".2f")],
-            )
-        )
-        return metric_trend
+        return build_metric_trend(filtered, metric, unit)
 
     # Peer Benchmarking Scatterplot
     @render_altair
@@ -501,28 +467,7 @@ def server(input, output, session):
         filtered = p1_filtered_data()
         metric = p1_selected_metric()
         unit = METRIC_CHOICES[metric]
-
-        if filtered.empty:
-            return empty_chart()
-
-        chart = (
-            alt.Chart(filtered)
-            .mark_circle(size=60)
-            .encode(
-                x=alt.X("Revenue:Q", title="Revenue ($)"),
-                y=alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
-                color=alt.Color("Category:N", scale=alt.Scale(scheme="viridis")),
-                tooltip=[
-                    "Company",
-                    "Category",
-                    "Year:O",
-                    alt.Tooltip("Revenue:Q", format=",.0f"),
-                    alt.Tooltip(f"{metric}:Q", format=",.2f"),
-                ],
-            )
-            .properties(title=f"Revenue vs {metric}", width="container")
-        )
-        return chart
+        return build_peer_scatter(filtered, metric, unit)
 
     # Company Details
     @render.data_frame

--- a/src/charts/altair_charts.py
+++ b/src/charts/altair_charts.py
@@ -1,0 +1,155 @@
+"""Pure Altair chart builder functions — no Shiny imports."""
+
+import altair as alt
+import pandas as pd
+
+from components.empty_chart import empty_chart
+
+
+def build_sector_bar(data: pd.DataFrame, metric: str, unit: str) -> alt.Chart:
+    """Bar chart of average metric by sector."""
+    if data.empty:
+        return empty_chart()
+    avg_by_sector = data.groupby("Category")[metric].mean().reset_index()
+    if avg_by_sector.empty:
+        return empty_chart()
+    return (
+        alt.Chart(avg_by_sector)
+        .mark_bar()
+        .encode(
+            x=alt.X("Category:N", title="Sector", sort="-y"),
+            y=alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
+            color=alt.Color(
+                "Category:N",
+                scale=alt.Scale(scheme="viridis"),
+                legend=None,
+            ),
+            tooltip=["Category", alt.Tooltip(f"{metric}:Q", format=".2f")],
+        )
+        .properties(title=f"Average {metric} by Sector", width="container")
+    )
+
+
+def build_metric_trend(data: pd.DataFrame, metric: str, unit: str) -> alt.Chart:
+    """Line chart of metric trend over time by sector."""
+    if data.empty:
+        return empty_chart()
+    observed_trend = data.groupby(["Year", "Category"], as_index=False)[metric].mean()
+    if observed_trend.empty:
+        return empty_chart()
+    return (
+        alt.Chart(observed_trend)
+        .mark_line(point=True)
+        .encode(
+            alt.X("Year:O", title="Year"),
+            alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
+            color=alt.Color("Category:N", scale=alt.Scale(scheme="viridis")),
+            tooltip=["Year", "Category", alt.Tooltip(f"{metric}:Q", format=".2f")],
+        )
+    )
+
+
+def build_peer_scatter(data: pd.DataFrame, metric: str, unit: str) -> alt.Chart:
+    """Scatter plot of Revenue vs selected metric."""
+    if data.empty:
+        return empty_chart()
+    return (
+        alt.Chart(data)
+        .mark_circle(size=60)
+        .encode(
+            x=alt.X("Revenue:Q", title="Revenue ($)"),
+            y=alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
+            color=alt.Color("Category:N", scale=alt.Scale(scheme="viridis")),
+            tooltip=[
+                "Company",
+                "Category",
+                "Year:O",
+                alt.Tooltip("Revenue:Q", format=",.0f"),
+                alt.Tooltip(f"{metric}:Q", format=",.2f"),
+            ],
+        )
+        .properties(title=f"Revenue vs {metric}", width="container")
+    )
+
+
+def build_revenue_over_time(data: pd.DataFrame, company: str) -> alt.Chart:
+    """Bar chart of yearly revenue for a single company (Page 2)."""
+    if data.empty:
+        return empty_chart()
+    return (
+        alt.Chart(data)
+        .mark_bar()
+        .encode(
+            x=alt.X("Year:O", title="Year"),
+            y=alt.Y("Revenue:Q", title="Revenue ($ millions)"),
+            tooltip=[
+                alt.Tooltip("Year:O"),
+                alt.Tooltip("Revenue:Q", format=",.0f"),
+            ],
+        )
+        .properties(
+            title=f"Revenue Over Time — {company}",
+            width="container",
+        )
+    )
+
+
+def build_ratio_over_time(data: pd.DataFrame, company: str, metric: str) -> alt.Chart:
+    """Line chart of a ratio metric over time for a single company (Page 2)."""
+    if data.empty:
+        return empty_chart()
+    return (
+        alt.Chart(data)
+        .mark_line(point=True)
+        .encode(
+            x=alt.X("Year:O", title="Year"),
+            y=alt.Y(f"{metric}:Q", title=metric),
+            tooltip=[
+                alt.Tooltip("Year:O"),
+                alt.Tooltip(f"{metric}:Q", format=".2f"),
+            ],
+        )
+        .properties(
+            title=f"{metric} Over Time — {company}",
+            width="container",
+        )
+    )
+
+
+def build_cash_flows(data: pd.DataFrame, company: str) -> alt.Chart:
+    """Grouped bar chart of Operating, Investing, Financing cash flows (Page 2)."""
+    if data.empty:
+        return empty_chart()
+
+    cf_cols = {
+        "Cash Flow from Operating": "Operating",
+        "Cash Flow from Investing": "Investing",
+        "Cash Flow from Financial Activities": "Financing",
+    }
+    melted = data[["Year"] + list(cf_cols.keys())].melt(
+        id_vars="Year", var_name="Flow Type", value_name="Amount"
+    )
+    melted["Flow Type"] = melted["Flow Type"].map(cf_cols)
+
+    return (
+        alt.Chart(melted)
+        .mark_bar()
+        .encode(
+            x=alt.X("Year:O", title="Year"),
+            y=alt.Y("Amount:Q", title="Cash Flow ($ millions)"),
+            color=alt.Color(
+                "Flow Type:N",
+                scale=alt.Scale(scheme="tableau10"),
+            ),
+            xOffset="Flow Type:N",
+            tooltip=[
+                alt.Tooltip("Year:O"),
+                alt.Tooltip("Flow Type:N"),
+                alt.Tooltip("Amount:Q", format=",.0f"),
+            ],
+        )
+        .properties(
+            title=f"Cash Flows — {company}",
+            width="container",
+        )
+    )

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,0 +1,60 @@
+import altair as alt
+import pandas as pd
+
+from charts.altair_charts import (
+    build_sector_bar,
+    build_metric_trend,
+    build_peer_scatter,
+    build_revenue_over_time,
+    build_ratio_over_time,
+    build_cash_flows,
+)
+from data import df
+
+
+def test_build_sector_bar_returns_chart():
+    chart = build_sector_bar(df, "Net Profit Margin", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_sector_bar_empty_data():
+    chart = build_sector_bar(pd.DataFrame(), "Net Profit Margin", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_metric_trend_returns_chart():
+    chart = build_metric_trend(df, "ROE", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_metric_trend_empty_data():
+    chart = build_metric_trend(pd.DataFrame(), "ROE", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_peer_scatter_returns_chart():
+    chart = build_peer_scatter(df, "Net Profit Margin", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_peer_scatter_empty_data():
+    chart = build_peer_scatter(pd.DataFrame(), "Net Profit Margin", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_revenue_over_time_returns_chart():
+    aapl = df[df["Company"] == "AAPL"]
+    chart = build_revenue_over_time(aapl, "AAPL")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_ratio_over_time_returns_chart():
+    aapl = df[df["Company"] == "AAPL"]
+    chart = build_ratio_over_time(aapl, "AAPL", "Current Ratio")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_cash_flows_returns_chart():
+    aapl = df[df["Company"] == "AAPL"]
+    chart = build_cash_flows(aapl, "AAPL")
+    assert isinstance(chart, alt.Chart)


### PR DESCRIPTION
Fixes #19 
### Proposed Changes
  - Created `src/charts/altair_charts.py` with 6 pure Altair chart builder functions: `build_sector_bar`, `build_metric_trend`, `build_peer_scatter` (extracted from Page 1), plus `build_revenue_over_time`, `build_ratio_over_time`, `build_cash_flows` (new for Page 2)
  - Updated `src/app.py` to import and delegate to chart builders, removing inline Altair code and unused `alt` import
  - Added `tests/test_charts.py` with 9 tests covering all 6 chart functions (including empty data edge cases)