### PR TITLE
feat: LLM quality improvements for AI Explorer

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -11,11 +11,11 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 # Ensure src/ is on the Python path (needed for Posit Connect deployment)
 sys.path.insert(0, str(Path(__file__).parent))
 
-from shiny import App, ui
+from shiny import App, ui  # noqa: E402
 
-from pages.ai_explorer import ai_explorer_server, ai_explorer_ui
-from pages.company import company_server, company_ui
-from pages.sector import sector_server, sector_ui
+from pages.ai_explorer import ai_explorer_server, ai_explorer_ui  # noqa: E402
+from pages.company import company_server, company_ui  # noqa: E402
+from pages.sector import sector_server, sector_ui  # noqa: E402
 
 # Load custom CSS
 CSS_PATH = Path(__file__).parent.parent / "assets" / "custom_styles.css"

--- a/src/pages/ai_explorer.py
+++ b/src/pages/ai_explorer.py
@@ -16,39 +16,71 @@ DATA_DESCRIPTION = """
 US Corporate financial statement data (2009–2023), covering 12 publicly
 traded companies across 8 sectors.
 
-Column descriptions:
+Company-sector mapping:
+- BANK: AIG, BCS
+- ELEC: INTC, NVDA
+- FINANCE: SHLDQ
+- FINTECH: PYPL
+- FOOD: MCD
+- IT: AAPL, GOOG, MSFT
+- LOGI: AMZN
+- MANUFACTURING: PCG
+
+Column descriptions (with approximate value ranges):
 - Year: fiscal year (2009–2023)
 - Company: ticker symbol (AAPL, GOOG, MSFT, AMZN, INTC, NVDA, PYPL, MCD, AIG, BCS, SHLDQ, PCG)
 - Category: sector (BANK, ELEC, FINANCE, FINTECH, FOOD, IT, LOGI, MANUFACTURING)
-- Market Cap(in B USD): market capitalization in billions
-- Revenue: annual revenue in millions USD
-- Gross Profit: gross profit in millions USD
-- Net Income: net income in millions USD
-- Earning Per Share: earnings per share in USD
-- EBITDA: earnings before interest, taxes, depreciation, and amortization in millions USD
-- Share Holder Equity: total shareholder equity in millions USD
-- Cash Flow from Operating: operating cash flow in millions USD
-- Cash Flow from Investing: investing cash flow in millions USD
-- Cash Flow from Financial Activities: financing cash flow in millions USD
-- Current Ratio: current assets / current liabilities (>1 = healthy liquidity)
-- Debt/Equity Ratio: total debt / shareholder equity
-- ROE: return on equity (%)
-- ROA: return on assets (%)
-- ROI: return on investment (%)
-- Net Profit Margin: net income / revenue (%)
-- Free Cash Flow per Share: free cash flow per share in USD
-- Return on Tangible Equity: return on tangible equity (%)
-- Number of Employees: headcount
-- Inflation Rate(in US): US inflation rate for that year (%)
+- Market Cap(in B USD): market capitalization in billions (~$1B–$3,000B)
+- Revenue: annual revenue in millions USD (~$500M–$400,000M)
+- Gross Profit: gross profit in millions USD (~$100M–$170,000M)
+- Net Income: net income in millions USD (~-$25,000M–$100,000M)
+- Earning Per Share: earnings per share in USD (~-$30–$6)
+- EBITDA: earnings before interest, taxes, depreciation, amortization in millions USD (~-$5,000M–$130,000M)
+- Share Holder Equity: total shareholder equity in millions USD (~-$15,000M–$270,000M)
+- Cash Flow from Operating: operating cash flow in millions USD (~-$5,000M–$120,000M)
+- Cash Flow from Investing: investing cash flow in millions USD (~-$50,000M–$30,000M)
+- Cash Flow from Financial Activities: financing cash flow in millions USD (~-$120,000M–$30,000M)
+- Current Ratio: current assets / current liabilities; >1 = healthy liquidity (~0.5–4.0)
+- Debt/Equity Ratio: total debt / shareholder equity (~-10–30)
+- ROE: return on equity in percent (~-80%–+160%)
+- ROA: return on assets in percent (~-15%–+30%)
+- ROI: return on investment in percent (~-20%–+50%)
+- Net Profit Margin: net income / revenue in percent (~-50%–+35%)
+- Free Cash Flow per Share: free cash flow per share in USD (~-$5–$7)
+- Return on Tangible Equity: return on tangible equity in percent (~-200%–+200%)
+- Number of Employees: headcount (~10,000–1,600,000)
+- Inflation Rate(in US): US inflation rate for that year in percent (~0.1%–8%)
 """
 
 GREETING = """
 Hi! I can help you explore the financial dataset. Try one of these:
 
-* <span class="suggestion">Show tech companies with profit margin above 20%</span>
-* <span class="suggestion">Compare all companies in 2022</span>
-* <span class="suggestion">Filter to banks with high debt/equity ratio</span>
-* <span class="suggestion">Which company had the highest ROE?</span>
+**Filter:** <span class="suggestion">Show tech companies with net profit margin above 20%</span>
+
+**Compare:** <span class="suggestion">Rank all companies by ROE in 2023</span>
+
+**Aggregate:** <span class="suggestion">What is the average revenue by sector?</span>
+
+**Health check:** <span class="suggestion">Which companies have a current ratio below 1?</span>
+"""
+
+EXTRA_INSTRUCTIONS = """
+You are a financial data analyst assistant. Follow these rules strictly:
+
+1. **Always use `querychat_query` before reporting any statistics.** Never guess,
+   estimate, or hallucinate numbers. If you cannot answer from the data, say so.
+
+2. Structure every response in this format:
+   - **Filters applied:** list the filters used (or "None" if showing all data)
+   - **Key stats:** 2-3 notable numbers from the query result
+   - **Insight:** one sentence interpreting the result
+   - **Try next:** one clickable follow-up suggestion as
+     `<span class="suggestion">suggestion text</span>`
+
+3. When the user asks about a sector, use the Category column (e.g., IT, BANK).
+   When they mention a company name, map it to the ticker in the Company column.
+
+4. Keep responses concise — no more than 5 sentences outside the structured format.
 """
 
 
@@ -59,6 +91,7 @@ def _get_qc():
         df,
         "financial_data",
         data_description=DATA_DESCRIPTION,
+        extra_instructions=EXTRA_INSTRUCTIONS,
         greeting=GREETING,
         client=ChatGithub(model="gpt-4.1-mini"),
     )


### PR DESCRIPTION
## Summary
- Add `extra_instructions` to `QueryChat()` enforcing structured reply format (filters applied, key stats, insight, follow-up suggestion) and hallucination guardrails (must call `querychat_query` before reporting any numbers)
- Enhance `DATA_DESCRIPTION` with company-sector mapping and approximate value ranges for all 22 columns
- Diversify `GREETING` suggestions to cover 4 query patterns: filter, compare/rank, aggregate, and financial health

Fixes #24

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] All 20 existing tests pass
- [x] Manually verify AI Explorer tab loads with updated greeting
- [x] Verify LLM responses follow the structured format
- [x] Verify LLM uses `querychat_query` tool calls instead of hallucinating
