### PR TITLE
feat: adaptive chart selection for AI Explorer

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -11,11 +11,11 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 # Ensure src/ is on the Python path (needed for Posit Connect deployment)
 sys.path.insert(0, str(Path(__file__).parent))
 
-from shiny import App, ui
+from shiny import App, ui  # noqa: E402
 
-from pages.ai_explorer import ai_explorer_server, ai_explorer_ui
-from pages.company import company_server, company_ui
-from pages.sector import sector_server, sector_ui
+from pages.ai_explorer import ai_explorer_server, ai_explorer_ui  # noqa: E402
+from pages.company import company_server, company_ui  # noqa: E402
+from pages.sector import sector_server, sector_ui  # noqa: E402
 
 # Load custom CSS
 CSS_PATH = Path(__file__).parent.parent / "assets" / "custom_styles.css"

--- a/src/charts/altair_charts.py
+++ b/src/charts/altair_charts.py
@@ -116,6 +116,70 @@ def build_ratio_over_time(data: pd.DataFrame, company: str, metric: str) -> alt.
     )
 
 
+def build_company_comparison_bar(
+    data: pd.DataFrame, metric: str, unit: str
+) -> alt.Chart:
+    """Bar chart comparing companies on a metric (used when 1 sector or 1 year)."""
+    if data.empty:
+        return empty_chart()
+    avg_by_company = data.groupby("Company")[metric].mean().reset_index()
+    return (
+        alt.Chart(avg_by_company)
+        .mark_bar()
+        .encode(
+            x=alt.X("Company:N", title="Company", sort="-y"),
+            y=alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
+            color=alt.Color(
+                "Company:N", scale=alt.Scale(scheme="viridis"), legend=None
+            ),
+            tooltip=["Company", alt.Tooltip(f"{metric}:Q", format=".2f")],
+        )
+        .properties(title=f"{metric} by Company", width="container")
+    )
+
+
+def build_single_company_summary(
+    data: pd.DataFrame, metric: str, unit: str
+) -> alt.Chart:
+    """Horizontal bar of key metrics for a single company (1 company, 1 year)."""
+    if data.empty:
+        return empty_chart()
+    key_metrics = ["Revenue", "Net Income", "EBITDA", "ROE", "ROA", "Net Profit Margin"]
+    available = [m for m in key_metrics if m in data.columns]
+    row = data.iloc[0]
+    company = row.get("Company", "Company")
+    melted = pd.DataFrame({"Metric": available, "Value": [row[m] for m in available]})
+    return (
+        alt.Chart(melted)
+        .mark_bar()
+        .encode(
+            y=alt.Y("Metric:N", title=None, sort=available),
+            x=alt.X("Value:Q", title="Value"),
+            color=alt.Color("Metric:N", scale=alt.Scale(scheme="viridis"), legend=None),
+            tooltip=["Metric", alt.Tooltip("Value:Q", format=",.2f")],
+        )
+        .properties(title=f"Key Metrics — {company}", width="container")
+    )
+
+
+def build_company_trend(data: pd.DataFrame, metric: str, unit: str) -> alt.Chart:
+    """Trend line colored by company (used when few companies, many years)."""
+    if data.empty:
+        return empty_chart()
+    trend = data.groupby(["Year", "Company"], as_index=False)[metric].mean()
+    return (
+        alt.Chart(trend)
+        .mark_line(point=True)
+        .encode(
+            alt.X("Year:O", title="Year"),
+            alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
+            color=alt.Color("Company:N", scale=alt.Scale(scheme="viridis")),
+            tooltip=["Year", "Company", alt.Tooltip(f"{metric}:Q", format=".2f")],
+        )
+        .properties(title=f"{metric} Trend by Company", width="container")
+    )
+
+
 def build_cash_flows(data: pd.DataFrame, company: str) -> alt.Chart:
     """Grouped bar chart of Operating, Investing, Financing cash flows (Page 2)."""
     if data.empty:

--- a/src/pages/ai_explorer.py
+++ b/src/pages/ai_explorer.py
@@ -8,7 +8,13 @@ from chatlas import ChatGithub
 from shiny import render, ui
 from shinywidgets import output_widget, render_altair
 
-from charts.altair_charts import build_metric_trend, build_sector_bar
+from charts.altair_charts import (
+    build_company_comparison_bar,
+    build_company_trend,
+    build_metric_trend,
+    build_sector_bar,
+    build_single_company_summary,
+)
 from components.empty_chart import empty_chart
 from data import METRIC_CHOICES, df
 
@@ -156,6 +162,14 @@ def ai_explorer_server(input, output, session):
         filtered = qc_vals.df()
         return f"{len(filtered)} rows"
 
+    def _data_shape(filtered):
+        """Return (n_companies, n_sectors, n_years) for adaptive chart selection."""
+        return (
+            filtered["Company"].nunique(),
+            filtered["Category"].nunique(),
+            filtered["Year"].nunique(),
+        )
+
     @render_altair
     def ai_chart_a():
         filtered = qc_vals.df()
@@ -163,6 +177,11 @@ def ai_explorer_server(input, output, session):
         unit = METRIC_CHOICES.get(metric, "")
         if filtered.empty:
             return empty_chart()
+        n_companies, n_sectors, n_years = _data_shape(filtered)
+        if n_companies == 1:
+            return build_single_company_summary(filtered, metric, unit)
+        if n_sectors == 1 or n_years == 1:
+            return build_company_comparison_bar(filtered, metric, unit)
         return build_sector_bar(filtered, metric, unit)
 
     @render_altair
@@ -172,6 +191,11 @@ def ai_explorer_server(input, output, session):
         unit = METRIC_CHOICES.get(metric, "")
         if filtered.empty:
             return empty_chart()
+        n_companies, n_sectors, n_years = _data_shape(filtered)
+        if n_years == 1:
+            return build_company_comparison_bar(filtered, metric, unit)
+        if n_companies <= 5:
+            return build_company_trend(filtered, metric, unit)
         return build_metric_trend(filtered, metric, unit)
 
     @render.download(filename="filtered_financial_data.csv")

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -2,12 +2,15 @@ import altair as alt
 import pandas as pd
 
 from charts.altair_charts import (
-    build_sector_bar,
+    build_cash_flows,
+    build_company_comparison_bar,
+    build_company_trend,
     build_metric_trend,
     build_peer_scatter,
-    build_revenue_over_time,
     build_ratio_over_time,
-    build_cash_flows,
+    build_revenue_over_time,
+    build_sector_bar,
+    build_single_company_summary,
 )
 from data import df
 
@@ -57,4 +60,37 @@ def test_build_ratio_over_time_returns_chart():
 def test_build_cash_flows_returns_chart():
     aapl = df[df["Company"] == "AAPL"]
     chart = build_cash_flows(aapl, "AAPL")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_company_comparison_bar_returns_chart():
+    banks = df[df["Category"] == "BANK"]
+    chart = build_company_comparison_bar(banks, "ROE", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_company_comparison_bar_empty_data():
+    chart = build_company_comparison_bar(pd.DataFrame(), "ROE", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_single_company_summary_returns_chart():
+    single = df[(df["Company"] == "AAPL") & (df["Year"] == 2022)]
+    chart = build_single_company_summary(single, "Net Profit Margin", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_single_company_summary_empty_data():
+    chart = build_single_company_summary(pd.DataFrame(), "Net Profit Margin", "%")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_company_trend_returns_chart():
+    it_companies = df[df["Category"] == "IT"]
+    chart = build_company_trend(it_companies, "Revenue", "USD")
+    assert isinstance(chart, alt.Chart)
+
+
+def test_build_company_trend_empty_data():
+    chart = build_company_trend(pd.DataFrame(), "Revenue", "USD")
     assert isinstance(chart, alt.Chart)


### PR DESCRIPTION
## Summary
- Add 3 new chart builders to `charts/altair_charts.py`: `build_company_comparison_bar`, `build_single_company_summary`, `build_company_trend`
- Add adaptive logic to `ai_chart_a` and `ai_chart_b` that detects data shape (`n_companies`, `n_sectors`, `n_years`) and selects the most meaningful chart type:
  - 1 company → summary bar of key metrics
  - 1 sector or 1 year → company comparison bar
  - ≤5 companies with multiple years → company trend lines
  - Default → sector bar / sector trend
- Add 6 tests for new chart builders
- Fix E402 lint in `app.py`

Fixes #25

## Test plan
- [x] `ruff check` passes
- [x] All 26 tests pass (6 new)
- [ ] Manually verify chart adapts when querying "Show AAPL in 2022" (single company summary)
- [ ] Verify "Show all banks" produces company comparison bar
- [ ] Verify "Compare everyone in 2020" produces company ranking bars
