### PR TITLE
feat: add QueryChat tests, eval dataset, and hybrid controls

### DIFF
--- a/src/pages/ai_explorer.py
+++ b/src/pages/ai_explorer.py
@@ -5,7 +5,7 @@ from functools import cache
 
 import querychat
 from chatlas import ChatGithub
-from shiny import render, ui
+from shiny import reactive, render, ui
 from shinywidgets import output_widget, render_altair
 
 from charts.altair_charts import (
@@ -16,7 +16,7 @@ from charts.altair_charts import (
     build_single_company_summary,
 )
 from components.empty_chart import empty_chart
-from data import METRIC_CHOICES, df
+from data import ALL_SECTORS, METRIC_CHOICES, df
 
 DATA_DESCRIPTION = """
 US Corporate financial statement data (2009–2023), covering 12 publicly
@@ -122,7 +122,12 @@ def ai_explorer_ui():
         )
 
     qc = _get_qc()
+    years = [str(y) for y in sorted(df["Year"].unique())]
     sidebar = ui.sidebar(
+        ui.input_selectize(
+            "ai_sector", "Sector", choices=["All"] + ALL_SECTORS, selected="All"
+        ),
+        ui.input_selectize("ai_year", "Year", choices=["All"] + years, selected="All"),
         qc.ui(),
         open="desktop",
         width=400,
@@ -180,6 +185,27 @@ def ai_explorer_server(input, output, session):
 
     qc = _get_qc()
     qc_vals = qc.server()
+
+    @reactive.effect
+    def _sync_dropdowns():
+        sector = input.ai_sector()
+        year = input.ai_year()
+        clauses = []
+        parts = []
+        if sector != "All":
+            clauses.append(f"Category = '{sector}'")
+            parts.append(sector)
+        if year != "All":
+            clauses.append(f"Year = {year}")
+            parts.append(year)
+        if clauses:
+            qc_vals.sql.set(
+                f"SELECT * FROM financial_data WHERE {' AND '.join(clauses)}"
+            )
+            qc_vals.title.set(" — ".join(parts))
+        else:
+            qc_vals.sql.set(None)
+            qc_vals.title.set(None)
 
     @render.text
     def ai_title():

--- a/tests/eval_dataset.csv
+++ b/tests/eval_dataset.csv
@@ -1,0 +1,9 @@
+query,expected_type,expected_tool,expected_description
+Show only IT companies,filter,querychat_update_dashboard,Filter Category=IT → AAPL GOOG MSFT
+Which company had the highest ROE in 2022?,query,querychat_query,Should query data and return specific company
+Filter to banks with debt/equity above 2,filter,querychat_update_dashboard,Category=BANK and Debt/Equity Ratio > 2
+Compare all companies in 2020,filter,querychat_update_dashboard,Year=2020 all 12 companies
+What is the average revenue by sector?,aggregate,querychat_query,Should compute and return sector averages
+Show NVDA history,filter,querychat_update_dashboard,Company=NVDA all years
+Rank companies by net profit margin in 2023,compare,querychat_query,Year=2023 sorted by Net Profit Margin
+Which sector is most profitable?,aggregate,querychat_query,Should query data not hallucinate

--- a/tests/test_querychat_behavior.py
+++ b/tests/test_querychat_behavior.py
@@ -1,0 +1,68 @@
+"""Standalone QueryChat behavior tests using qc.client() outside Shiny."""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("GITHUB_TOKEN"),
+    reason="GITHUB_TOKEN not set — skipping LLM-backed tests",
+)
+
+from pages.ai_explorer import DATA_DESCRIPTION, EXTRA_INSTRUCTIONS, GREETING  # noqa: E402
+from data import df  # noqa: E402
+
+import querychat  # noqa: E402
+from chatlas import ChatGithub  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def chat():
+    """Create a standalone chatlas.Chat from QueryChat.client()."""
+    qc = querychat.QueryChat(
+        df,
+        "financial_data",
+        data_description=DATA_DESCRIPTION,
+        extra_instructions=EXTRA_INSTRUCTIONS,
+        greeting=GREETING,
+        client=ChatGithub(model="gpt-4.1-mini"),
+    )
+    return qc.client()
+
+
+def _tool_names(chat_instance):
+    """Extract tool-call function names from the last assistant turn."""
+    turns = chat_instance.get_turns()
+    names = []
+    for turn in reversed(turns):
+        if turn.role == "assistant":
+            for part in turn.contents:
+                if hasattr(part, "name"):
+                    names.append(part.name)
+            break
+    return names
+
+
+def test_filter_uses_update_dashboard(chat):
+    """A filter prompt should invoke the querychat_update_dashboard tool."""
+    chat.chat("Show only IT companies")
+    names = _tool_names(chat)
+    assert "querychat_update_dashboard" in names, (
+        f"Expected update_dashboard, got {names}"
+    )
+
+
+def test_stats_use_querychat_query(chat):
+    """An aggregate question should invoke the querychat_query tool."""
+    chat.chat("What is the average revenue by sector?")
+    names = _tool_names(chat)
+    assert "querychat_query" in names, f"Expected querychat_query, got {names}"
+
+
+def test_response_has_structured_format(chat):
+    """Response should follow the structured format from EXTRA_INSTRUCTIONS."""
+    response = chat.chat("Which company had the highest ROE in 2022?")
+    text = str(response).lower()
+    assert any(
+        keyword in text for keyword in ["filters applied", "key stats", "insight"]
+    ), f"Response missing structured format keywords: {text[:300]}"


### PR DESCRIPTION
Fixes #40

### Proposed Changes
- Add `tests/eval_dataset.csv` with 8 LLM eval queries covering filter, compare, aggregate, and health-check categories
- Add `tests/test_querychat_behavior.py` with standalone QueryChat behavior tests (auto-skip without `GITHUB_TOKEN`)
- Add Sector and Year hybrid dropdown controls to AI Explorer that sync with QueryChat's SQL filter via `@reactive.effect`

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] All 26 existing tests pass
- [x] 3 new behavior tests skip gracefully without `GITHUB_TOKEN`
- [ ] Manually verify hybrid dropdowns filter data and sync with QueryChat in the app
